### PR TITLE
Exclude gas-price if loading recommended is disabled

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-ui-web3-tx "1.0.12-SNAPSHOT"
+(defproject district0x/district-ui-web3-tx "1.0.13-SNAPSHOT"
   :description "district UI module for handling web3 transactions"
   :url "https://github.com/district0x/district-ui-web3-tx"
   :license {:name "Eclipse Public License"

--- a/src/district/ui/web3_tx/events.cljs
+++ b/src/district/ui/web3_tx/events.cljs
@@ -35,6 +35,7 @@
         {:db (-> db
                (queries/merge-txs txs)
                (queries/assoc-opt :eip55? eip55?)
+               (queries/assoc-opt :disable-loading-recommended-gas-prices? disable-loading-recommended-gas-prices?)
                (queries/assoc-opt :disable-using-localstorage? disable-using-localstorage?)
                (queries/assoc-opt :recommended-gas-prices-load-interval recommended-gas-prices-load-interval)
                (queries/assoc-recommended-gas-price-option recommended-gas-price-option))
@@ -126,9 +127,11 @@
                    {:instance instance
                     :fn fn
                     :args args
-                    :tx-opts (merge
-                               {:gas-price (queries/recommended-gas-price db)}
-                               tx-opts)
+                    :tx-opts (if (queries/opt db :disable-loading-recommended-gas-prices?)
+                               tx-opts
+                               (merge
+                                {:gas-price (queries/recommended-gas-price db)}
+                                tx-opts))
                     :on-tx-hash [::tx-hash opts]
                     :on-tx-hash-error [::tx-hash-error opts]
                     :on-tx-receipt [::tx-receipt opts]


### PR DESCRIPTION
If loading recommended gas price is disabled, then it should leave the gas-price tx option out. This way, it uses the gas price the network suggests instead of setting it to zero.
This comes handy when using this module for networks other than Ethereum Mainnet where the ethgasstation service is not applicable.