### PR TITLE
Load web3-fx to for :web3/call and other fx-s

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [cljs-web3 "0.19.0-0-11"]
                  [day8.re-frame/forward-events-fx "0.0.6"]
                  [day8.re-frame/http-fx "0.1.6"]
-                 [district0x.re-frame/web3-fx "1.0.5"]
+                 [district0x.re-frame/web3-fx "1.0.7"]
                  [district0x/bignumber "1.0.3"]
                  [district0x/district-cljs-utils "1.0.4"]
                  [district0x/district-ui-web3 "1.3.2"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-ui-web3-tx "1.0.13-SNAPSHOT"
+(defproject district0x/district-ui-web3-tx "1.0.14-SNAPSHOT"
   :description "district UI module for handling web3 transactions"
   :url "https://github.com/district0x/district-ui-web3-tx"
   :license {:name "Eclipse Public License"

--- a/src/district/ui/web3_tx/events.cljs
+++ b/src/district/ui/web3_tx/events.cljs
@@ -7,6 +7,7 @@
             [cljs.spec.alpha :as s]
             [district.cljs-utils :as cljs-utils]
             [district.ui.web3-tx.queries :as queries]
+            [district0x.re-frame.web3-fx]
             [district.ui.web3.events :as web3-events]
             [district.ui.web3.queries :as web3-queries]
             [district0x.re-frame.spec-interceptors


### PR DESCRIPTION
If these effects are not loaded, re-frame doesn't know how to handle
them. They could be added in the application that uses this library
(district-ui-web3-tx), but this is more convenient.

**NB** merge and publish first https://github.com/district0x/re-frame-web3-fx/pull/12 and then this